### PR TITLE
Fix for M8

### DIFF
--- a/contracts/Zunami.sol
+++ b/contracts/Zunami.sol
@@ -343,4 +343,8 @@ contract Zunami is Context, Ownable, ERC20, IZunami {
         }
         accDepositPending[_msgSender()] = [0, 0, 0];
     }
+
+    function renounceOwnership() public view override onlyOwner {
+        revert('Zunami must have an owner');
+    }
 }


### PR DESCRIPTION
There is the issue:
"M8: Open Zeppelin's Ownable patern allows the current owner to renounce
the ownership of the contract (can happen even accidentally), which
could potentially cause inability to call any function with the
onlyOwner modifier."