### PR TITLE
Fix for M8

### DIFF
--- a/contracts/Zunami.sol
+++ b/contracts/Zunami.sol
@@ -343,4 +343,8 @@ contract Zunami is Context, Ownable, ERC20, IZunami {
         }
         accDepositPending[_msgSender()] = [0, 0, 0];
     }
+
+    function renounceOwnership() public view override onlyOwner {
+        revert('Zunami must have an owner');
+    }
 }

--- a/contracts/strategies/BaseCurveConvex.sol
+++ b/contracts/strategies/BaseCurveConvex.sol
@@ -262,4 +262,8 @@ contract BaseCurveConvex is Context, Ownable {
     function updateZunamiLpInStrat(uint256 _amount, bool _isMint) external onlyZunami {
         _isMint ? (zunamiLpInStrat += _amount) : (zunamiLpInStrat -= _amount);
     }
+
+    function renounceOwnership() public view override onlyOwner {
+        revert('The strategy must have an owner');
+    }
 }

--- a/contracts/strategies/BaseCurveConvex2.sol
+++ b/contracts/strategies/BaseCurveConvex2.sol
@@ -378,4 +378,8 @@ contract BaseCurveConvex2 is Context, Ownable {
     function updateZunamiLpInStrat(uint256 _amount, bool _isMint) external onlyZunami {
         _isMint ? (zunamiLpInStrat += _amount) : (zunamiLpInStrat -= _amount);
     }
+
+    function renounceOwnership() public view override onlyOwner {
+        revert('The strategy must have an owner');
+    }
 }

--- a/contracts/strategies/BaseCurveConvex4.sol
+++ b/contracts/strategies/BaseCurveConvex4.sol
@@ -373,4 +373,8 @@ contract BaseCurveConvex4 is Context, Ownable {
     function updateZunamiLpInStrat(uint256 _amount, bool _isMint) external onlyZunami {
         _isMint ? (zunamiLpInStrat += _amount) : (zunamiLpInStrat -= _amount);
     }
+
+    function renounceOwnership() public view override onlyOwner {
+        revert('The strategy must have an owner');
+    }
 }


### PR DESCRIPTION
There is the issue:
"M8: Open Zeppelin's Ownable patern allows the current owner to renounce
the ownership of the contract (can happen even accidentally), which
could potentially cause inability to call any function with the
onlyOwner modifier."